### PR TITLE
fix: wrong type descriptor in ProjectAWSCMEK class

### DIFF
--- a/tidbcloudy/specification.py
+++ b/tidbcloudy/specification.py
@@ -366,8 +366,8 @@ class ClusterInfoOfRestore(TiDBCloudyBase):
 
 class ProjectAWSCMEK(TiDBCloudyBase):
     __slots__ = ["_region", "_kms_arn"]
-    region: str = None
-    kms_arn: str = None
+    region: str = TiDBCloudyField(str)
+    kms_arn: str = TiDBCloudyField(str)
 
     def __repr__(self):
         return "<region={}, kms_arn={}>".format(


### PR DESCRIPTION
Fix the issue that `project.list_aws_cmek()` fails to list the AWS CMEKs in a project and reports `AttributeError: 'NoneType' object has no attribute 'value_type'`.